### PR TITLE
feat: move button from display back to input

### DIFF
--- a/docs/src/content/docs/actions/AWS/lambda-invoke.mdx
+++ b/docs/src/content/docs/actions/AWS/lambda-invoke.mdx
@@ -11,7 +11,7 @@ import PropMarker from '@components/PropMarker.astro'
 <FrameworkSelect>
 	<FrameworkContent>
 		<Fragment slot="cdk">
-			[Source](https://github.com/buttonize/buttonize-cdk/blob/master/src/actions/lambda/invoke.ts)
+			[Source](https://github.com/buttonize/buttonize/blob/master/cdk/actions/lambda/invoke.ts)
 		</Fragment>
 	</FrameworkContent>
 </FrameworkSelect>
@@ -38,7 +38,7 @@ Invoke a Lambda function.
             id: 'name',
             label: 'What is your name?'
           }),
-          Display.button({
+          Input.button({
             label: 'Save to database',
             onClick: Action.aws.lambda.invoke(
               new NodejsFunction(this, 'MyLambda', {

--- a/docs/src/content/docs/actions/Buttonize/change-page.mdx
+++ b/docs/src/content/docs/actions/Buttonize/change-page.mdx
@@ -11,7 +11,7 @@ import PropMarker from '@components/PropMarker.astro'
 <FrameworkSelect>
 	<FrameworkContent>
 		<Fragment slot="cdk">
-			[Source](https://github.com/buttonize/buttonize-cdk/blob/master/src/actions/lambda/invoke.ts)
+			[Source](https://github.com/buttonize/buttonize/blob/master/cdk/actions/lambda/invoke.ts)
 		</Fragment>
 	</FrameworkContent>
 </FrameworkSelect>
@@ -38,7 +38,7 @@ Invoke a Lambda function.
             id: 'name',
             label: 'What is your name?'
           }),
-          Display.button({
+          Input.button({
             label: 'Save to database',
             onClick: Action.aws.lambda.invoke(
               new NodejsFunction(this, 'MyLambda', {

--- a/docs/src/content/docs/components/display-code.mdx
+++ b/docs/src/content/docs/components/display-code.mdx
@@ -16,7 +16,7 @@ import SizingProps from '../../../components/SizingProps.mdx'
 <FrameworkSelect>
 	<FrameworkContent>
 		<Fragment slot="cdk">
-			[Source](https://github.com/buttonize/buttonize-cdk/blob/master/src/components/display/code.ts)
+			[Source](https://github.com/buttonize/buttonize/blob/master/cdk/components/display/code.ts)
 		</Fragment>
 	</FrameworkContent>
 </FrameworkSelect>

--- a/docs/src/content/docs/components/display-grid.mdx
+++ b/docs/src/content/docs/components/display-grid.mdx
@@ -16,7 +16,7 @@ import SpacingProps from '../../../components/SpacingProps.mdx'
 <FrameworkSelect>
 	<FrameworkContent>
 		<Fragment slot="cdk">
-			[Source](https://github.com/buttonize/buttonize-cdk/blob/master/src/components/display/grid.ts)
+			[Source](https://github.com/buttonize/buttonize/blob/master/cdk/components/display/grid.ts)
 		</Fragment>
 	</FrameworkContent>
 </FrameworkSelect>

--- a/docs/src/content/docs/components/display-heading.mdx
+++ b/docs/src/content/docs/components/display-heading.mdx
@@ -16,7 +16,7 @@ import SizingProps from '../../../components/SizingProps.mdx'
 <FrameworkSelect>
 	<FrameworkContent>
 		<Fragment slot="cdk">
-			[Source](https://github.com/buttonize/buttonize-cdk/blob/master/src/components/display/heading.ts)
+			[Source](https://github.com/buttonize/buttonize/blob/master/cdk/components/display/heading.ts)
 		</Fragment>
 	</FrameworkContent>
 </FrameworkSelect>

--- a/docs/src/content/docs/components/display-image.mdx
+++ b/docs/src/content/docs/components/display-image.mdx
@@ -16,7 +16,7 @@ import SizingProps from '../../../components/SizingProps.mdx'
 <FrameworkSelect>
 	<FrameworkContent>
 		<Fragment slot="cdk">
-			[Source](https://github.com/buttonize/buttonize-cdk/blob/master/src/components/display/image.ts)
+			[Source](https://github.com/buttonize/buttonize/blob/master/cdk/components/display/image.ts)
 		</Fragment>
 	</FrameworkContent>
 </FrameworkSelect>

--- a/docs/src/content/docs/components/display-json.mdx
+++ b/docs/src/content/docs/components/display-json.mdx
@@ -16,7 +16,7 @@ import SizingProps from '../../../components/SizingProps.mdx'
 <FrameworkSelect>
 	<FrameworkContent>
 		<Fragment slot="cdk">
-			[Source](https://github.com/buttonize/buttonize-cdk/blob/master/src/components/display/json.ts)
+			[Source](https://github.com/buttonize/buttonize/blob/master/cdk/components/display/json.ts)
 		</Fragment>
 	</FrameworkContent>
 </FrameworkSelect>

--- a/docs/src/content/docs/components/display-markdown.mdx
+++ b/docs/src/content/docs/components/display-markdown.mdx
@@ -16,7 +16,7 @@ import SizingProps from '../../../components/SizingProps.mdx'
 <FrameworkSelect>
 	<FrameworkContent>
 		<Fragment slot="cdk">
-			[Source](https://github.com/buttonize/buttonize-cdk/blob/master/src/components/display/markdown.ts)
+			[Source](https://github.com/buttonize/buttonize/blob/master/cdk/components/display/markdown.ts)
 		</Fragment>
 	</FrameworkContent>
 </FrameworkSelect>

--- a/docs/src/content/docs/components/display-section.mdx
+++ b/docs/src/content/docs/components/display-section.mdx
@@ -16,7 +16,7 @@ import SizingProps from '../../../components/SizingProps.mdx'
 <FrameworkSelect>
 	<FrameworkContent>
 		<Fragment slot="cdk">
-			[Source](https://github.com/buttonize/buttonize-cdk/blob/master/src/components/display/section.ts)
+			[Source](https://github.com/buttonize/buttonize/blob/master/cdk/components/display/section.ts)
 		</Fragment>
 	</FrameworkContent>
 </FrameworkSelect>

--- a/docs/src/content/docs/components/display-text.mdx
+++ b/docs/src/content/docs/components/display-text.mdx
@@ -16,7 +16,7 @@ import SizingProps from '../../../components/SizingProps.mdx'
 <FrameworkSelect>
 	<FrameworkContent>
 		<Fragment slot="cdk">
-			[Source](https://github.com/buttonize/buttonize-cdk/blob/master/src/components/display/text.ts)
+			[Source](https://github.com/buttonize/buttonize/blob/master/cdk/components/display/text.ts)
 		</Fragment>
 	</FrameworkContent>
 </FrameworkSelect>

--- a/docs/src/content/docs/components/display-video.mdx
+++ b/docs/src/content/docs/components/display-video.mdx
@@ -16,7 +16,7 @@ import SizingProps from '../../../components/SizingProps.mdx'
 <FrameworkSelect>
 	<FrameworkContent>
 		<Fragment slot="cdk">
-			[Source](https://github.com/buttonize/buttonize-cdk/blob/master/src/components/display/video.ts)
+			[Source](https://github.com/buttonize/buttonize/blob/master/cdk/components/display/video.ts)
 		</Fragment>
 	</FrameworkContent>
 </FrameworkSelect>

--- a/docs/src/content/docs/components/input-button.mdx
+++ b/docs/src/content/docs/components/input-button.mdx
@@ -1,6 +1,6 @@
 ---
-title: Display.button
-description: Display.button displays a button with which a user can trigger an action.
+title: Input.button
+description: Input.button displays a button with which a user can trigger an action.
 ---
 
 import { TabItem, Tabs } from '@astrojs/starlight/components'
@@ -16,7 +16,7 @@ import SizingProps from '../../../components/SizingProps.mdx'
 <FrameworkSelect>
 	<FrameworkContent>
 		<Fragment slot="cdk">
-			[Source](https://github.com/buttonize/buttonize-cdk/blob/master/src/components/display/button.ts)
+			[Source](https://github.com/buttonize/buttonize/blob/master/cdk/components/input/button.ts)
 		</Fragment>
 	</FrameworkContent>
 </FrameworkSelect>
@@ -26,7 +26,7 @@ Renders an interactable button.
 The button can be used to trigger a lambda, change pages within a Buttonize app, or interact with some other AWS services via Buttonize [Actions](/core-concepts/actions/#available-actions).
 
 ```ansi frame="none"
-[38;5;39mDisplay.button[0m(props)
+[38;5;39mInput.button[0m(props)
 ```
 
 ## Usage
@@ -40,7 +40,7 @@ The button can be used to trigger a lambda, change pages within a Buttonize app,
       name: 'Demo App'
     }).page('DemoPage', {
       body: [
-        Display.button({
+        Input.button({
           label: 'Next Page',
           onClick: Action.aws.lambda.invoke(yourFunction)
         })
@@ -55,7 +55,7 @@ The button can be used to trigger a lambda, change pages within a Buttonize app,
 <ComponentDemo
 	components={[
 		{
-			typeName: 'display.button',
+			typeName: 'input.button',
 			props: {
 				label: 'Next Page',
 				onClick: {

--- a/docs/src/content/docs/components/input-chat.mdx
+++ b/docs/src/content/docs/components/input-chat.mdx
@@ -16,7 +16,7 @@ import SizingProps from '../../../components/SizingProps.mdx'
 <FrameworkSelect>
 	<FrameworkContent>
 		<Fragment slot="cdk">
-			[Source](https://github.com/buttonize/buttonize-cdk/blob/master/src/components/input/chat.ts)
+			[Source](https://github.com/buttonize/buttonize/blob/master/cdk/components/input/chat.ts)
 		</Fragment>
 	</FrameworkContent>
 </FrameworkSelect>

--- a/docs/src/content/docs/components/input-select.mdx
+++ b/docs/src/content/docs/components/input-select.mdx
@@ -16,7 +16,7 @@ import SizingProps from '../../../components/SizingProps.mdx'
 <FrameworkSelect>
 	<FrameworkContent>
 		<Fragment slot="cdk">
-			[Source](https://github.com/buttonize/buttonize-cdk/blob/master/src/components/input/select.ts)
+			[Source](https://github.com/buttonize/buttonize/blob/master/cdk/components/input/select.ts)
 		</Fragment>
 	</FrameworkContent>
 </FrameworkSelect>

--- a/docs/src/content/docs/components/input-text.mdx
+++ b/docs/src/content/docs/components/input-text.mdx
@@ -16,7 +16,7 @@ import SizingProps from '../../../components/SizingProps.mdx'
 <FrameworkSelect>
 	<FrameworkContent>
 		<Fragment slot="cdk">
-			[Source](https://github.com/buttonize/buttonize-cdk/blob/master/src/components/display/text.ts)
+			[Source](https://github.com/buttonize/buttonize/blob/master/cdk/components/display/text.ts)
 		</Fragment>
 	</FrameworkContent>
 </FrameworkSelect>

--- a/docs/src/content/docs/components/input-toggle.mdx
+++ b/docs/src/content/docs/components/input-toggle.mdx
@@ -16,7 +16,7 @@ import SizingProps from '../../../components/SizingProps.mdx'
 <FrameworkSelect>
 	<FrameworkContent>
 		<Fragment slot="cdk">
-			[Source](https://github.com/buttonize/buttonize-cdk/blob/master/src/components/input/toggle.ts)
+			[Source](https://github.com/buttonize/buttonize/blob/master/cdk/components/input/toggle.ts)
 		</Fragment>
 	</FrameworkContent>
 </FrameworkSelect>

--- a/docs/src/content/docs/core-concepts/actions.mdx
+++ b/docs/src/content/docs/core-concepts/actions.mdx
@@ -35,7 +35,7 @@ Currently there are two main groups of of actions:
       .page('MyButtonizePage', {
         body: [
           Display.heading('Hello, this is my page'),
-          Display.button({
+          Input.button({
             label: 'Next page',
             onClick: Action.buttonize.app.changePage('SecondPage')
           })
@@ -49,7 +49,7 @@ Currently there are two main groups of of actions:
             label: 'What is your name?',
             placeholder: 'Joe'
           }),
-          Display.button({
+          Input.button({
             label: 'Register',
             variant: 'secondary',
             onClick: Action.aws.lambda.invoke(

--- a/docs/src/content/docs/core-concepts/apps-and-pages.mdx
+++ b/docs/src/content/docs/core-concepts/apps-and-pages.mdx
@@ -39,7 +39,7 @@ Apps and pages are the main building blocks of Buttonize. Every app is composed 
       .page('MyButtonizePage', {
         body: [
           Display.heading('Hello, this is my page'),
-          Display.button({
+          Input.button({
             label: 'Next page',
             onClick: Action.buttonize.app.changePage('SecondPage')
           })
@@ -54,7 +54,7 @@ Apps and pages are the main building blocks of Buttonize. Every app is composed 
             placeholder: 'Joe'
           }),
           Display.text('Hello: {{name}}'),
-          Display.button({
+          Input.button({
             label: 'Go back',
             onClick: Action.buttonize.app.changePage('MyButtonizePage')
           })
@@ -81,7 +81,7 @@ Apps and pages are the main building blocks of Buttonize. Every app is composed 
 			}
 		},
 		{
-			typeName: 'display.button',
+			typeName: 'input.button',
 			props: {
 				label: 'Next page',
 				onClick: {
@@ -126,7 +126,7 @@ Apps and pages are the main building blocks of Buttonize. Every app is composed 
 			}
 		},
 		{
-			typeName: 'display.button',
+			typeName: 'input.button',
 			props: {
 				label: 'Go back',
 				onClick: {


### PR DESCRIPTION
According to our research it makes more sense for `Button` to be `Input` rather than `Display`.

`buttonize`: https://github.com/buttonize/buttonize/pull/2